### PR TITLE
chore: bump mizchi/x to 0.2.0

### DIFF
--- a/moon.mod.json
+++ b/moon.mod.json
@@ -3,7 +3,7 @@
   "version": "0.5.0",
   "deps": {
     "mizchi/llm": "0.2.2",
-    "mizchi/x": "0.1.3",
+    "mizchi/x": "0.2.0",
     "mizchi/tui": "0.7.0"
   },
   "source": "src",


### PR DESCRIPTION
## Summary
- Bump `mizchi/x` from 0.1.3 to 0.2.0
- `moon check` and `moon test` (265/265) pass locally

🤖 Generated with [Claude Code](https://claude.com/claude-code)